### PR TITLE
Parsing fixes

### DIFF
--- a/src/_monkeyYaml.py
+++ b/src/_monkeyYaml.py
@@ -44,8 +44,8 @@ def load(str):
     return dict
 
 def myReadValue(lines, value):
-    if value == ">":
-        (lines, value) = myMultiline(lines, value)
+    if value == ">" or value == "|":
+        (lines, value) = myMultiline(lines, value, value == "|")
         value = value + "\n"
         return (lines, value)
     if lines and not value and myMaybeList(lines[0]):
@@ -99,21 +99,27 @@ def myFlowList(value):
     values = result.group(1).split(",")
     return [myReadOneLine(v.strip()) for v in values]
 
-def myMultiline(lines, value):
+def myMultiline(lines, value, preserveNewlines=False):
     # assume no explcit indentor (otherwise have to parse value)
     value = []
     indent = myLeadingSpaces(lines[0])
     while lines:
         line = lines.pop(0)
         if myIsAllSpaces(line):
-            value += ["\n"]
+            if preserveNewlines:
+                value += [""]
+            else:
+                value += ["\n"]
         elif myLeadingSpaces(line) < indent:
             lines.insert(0, line)
             break;
         else:
             value += [line[(indent):]]
-    value = " ".join(value)
-    return (lines, value)
+    joinOn = " "
+    if preserveNewlines:
+      joinOn = "\n"
+
+    return (lines, joinOn.join(value))
 
 def myIsAllSpaces(line):
     return len(line.strip()) == 0

--- a/test/fixtures/negative.js
+++ b/test/fixtures/negative.js
@@ -1,0 +1,11 @@
+// fake copyright comment
+/*---
+info: >
+    Sample test info
+description: Sample test description
+negative:
+  phase: early
+  type: SyntaxError
+---*/
+
+???

--- a/test/test_monkeyYaml.py
+++ b/test/test_monkeyYaml.py
@@ -49,24 +49,21 @@ class TestMonkeyYAMLParsing(unittest.TestCase):
 
     def test_Multiline_2(self):
         lines = [" foo", " bar"]
-        value = ">"
-        y = "\n".join([value] + lines)
-        (lines, value) = monkeyYaml.myMultiline(lines, value)
+        y = "\n".join([">"] + lines)
+        (lines, value) = monkeyYaml.myMultiline(lines)
         self.assertEqual(lines, [])
         self.assertEqual(value, yaml.load(y))
 
     def test_Multiline_3(self):
         lines = ["  foo", "  bar"]
-        value = ">"
-        y = "\n".join([value] + lines)
-        (lines, value) = monkeyYaml.myMultiline(lines, value)
+        y = "\n".join([">"] + lines)
+        (lines, value) = monkeyYaml.myMultiline(lines)
         self.assertEqual(lines, [])
         self.assertEqual(value, yaml.load(y))
 
     def test_Multiline_4(self):
         lines = ["    foo", "    bar", "  other: 42"]
-        value = ">"
-        (lines, value) = monkeyYaml.myMultiline(lines, value)
+        (lines, value) = monkeyYaml.myMultiline(lines)
         self.assertEqual(lines, ["  other: 42"])
         self.assertEqual(value, "foo bar")
 
@@ -176,6 +173,15 @@ description: |
 
   to: have
   nested: data
+"""
+        self.assertEqual(monkeyYaml.load(y), yaml.load(y))
+
+    def test_value_multiline(self):
+        y = """
+description:
+  This is a multi-line value
+
+  whose trailing newline should be stripped
 """
         self.assertEqual(monkeyYaml.load(y), yaml.load(y))
 

--- a/test/test_monkeyYaml.py
+++ b/test/test_monkeyYaml.py
@@ -169,6 +169,15 @@ es6id:  19.1.2.1
 """
         self.assertEqual(monkeyYaml.load(y), yaml.load(y))
 
+    def test_no_folding(self):
+        y = """
+description: |
+  This is text that, naively parsed, would appear
+
+  to: have
+  nested: data
+"""
+        self.assertEqual(monkeyYaml.load(y), yaml.load(y))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_monkeyYaml.py
+++ b/test/test_monkeyYaml.py
@@ -185,5 +185,26 @@ description:
 """
         self.assertEqual(monkeyYaml.load(y), yaml.load(y))
 
+    def test_nested_1(self):
+        y = """
+es61d: 19.1.2.1
+negative:
+    stage: early
+    type: ReferenceError
+description: foo
+"""
+        self.assertEqual(monkeyYaml.load(y), yaml.load(y))
+
+    def test_nested_2(self):
+        y = """
+es61d: 19.1.2.1
+first:
+    second_a:
+        third: 1
+    second_b: 3
+description: foo
+"""
+        self.assertEqual(monkeyYaml.load(y), yaml.load(y))
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_parseTestRecord.py
+++ b/test/test_parseTestRecord.py
@@ -171,7 +171,13 @@ flags: [onlyStrict]"""
 
 """, record['test'])
 
+    def test_negative(self):
+        name = 'fixtures/negative.js'
+        contents = slurpFile(name)
+        record = parseTestRecord(contents, name)
 
+        self.assertEqual('early', record['negative']['phase'])
+        self.assertEqual('SyntaxError', record['negative']['type'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Extend YAML parser

Some recent changes in Test262 rely on previously-unused aspects of the YAML
grammar. Update the simplified YAML parser contained in this project to support
them.

@leobalter @littledan @tschneidereit Any of you folks mind reviewing this and
merging it if it looks okay?
